### PR TITLE
0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0
+
+- upgrade `serializable_core` to version `0.11.0` since
+  this version now generates from methods which now allows
+  convert objects from generic values.
+- move `SerializedName` to `built_mirrors` library since
+  the serialized name is now generated at build time
+
 ## 0.14.0
 
 - upgrade `sourge_gen` to version `^0.9.0`

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -22,17 +22,6 @@ class IgnoreIf extends Annotation {
   const IgnoreIf(this.ignoreIfFunction);
 }
 
-/**
- * Annotation class to describe properties of a class member.
- */
-class SerializedName extends Annotation {
-  final String name;
-  
-  const SerializedName(this.name);
-  
-  String toString() => "DartsonProperty: Name: ${name}";
-}
-
 ///this annotation describes if the objects contains cyclical reference to other objects
 const cyclical = const _Cyclical();
 

--- a/lib/src/caches.dart
+++ b/lib/src/caches.dart
@@ -1,16 +1,5 @@
 part of dson;
 
-Map<DeclarationMirror, String> _propNameCache = {};
-
-/// If the [declaration] is annotated with `@SerializedName` then it returns the value of the annotation,
-/// if not it returns the default [varName]
-String _getFieldNameFromDeclaration(DeclarationMirror declaration) =>
-    declaration.annotations == null
-        ? declaration.name
-        : _propNameCache.putIfAbsent(declaration, () =>
-    (declaration.annotations.firstWhere((a) => a is SerializedName, orElse: () => null) as SerializedName)?.name ??
-        declaration.name);
-
 Map _uIdFromClassCache = {};
 
 /// gets the name of the attribute annotated with `@uId`, if there is none then returns 'id'
@@ -23,7 +12,7 @@ String _getUIdAttrFromClass(ClassMirror cm) =>
 
 /// Checks if the annotation [ignored] is over the [declaration]
 bool _getIsIgnoredFromDeclaration(DeclarationMirror declaration) =>
-    declaration.annotations?.any((a) => a is _Ignore) ?? false;
+    declaration.annotations?.any((a) => a == ignore) ?? false;
 
 /// Cheks if the annotation [Cyclical] is not over the class of the object
 _isCyclical(ClassMirror cm) =>

--- a/lib/src/serializer.dart
+++ b/lib/src/serializer.dart
@@ -159,7 +159,7 @@ void _pushField(String fieldName, DeclarationMirror variable, SerializableMap ob
   Object value = obj[fieldName];
 //  _serLog.finer("Start serializing field: ${fieldName}");
 
-  fieldName = _getFieldNameFromDeclaration(variable);
+  fieldName = variable.name;
   // check if there is a DartsonProperty annotation
 
 //  _serLog.finer("depth: $depth");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dson_core
-version: 0.14.0
+version: 0.15.0
 author: Luis Vargas <luisvargastijerino@gmail.com>
 description: Convert Objects to Json and Json to Objects
 homepage: https://github.com/luisvt/dson_core
@@ -10,12 +10,9 @@ dependencies:
   build: ^0.12.0
   analyzer: ^0.32.0
   logging: ^0.11.0
-  built_mirrors_core: ^0.9.0
-  serializable_core: ^0.10.0
+  serializable_core: ^0.11.0
 #  serializable_core:
-#    path: ../serializable
-#  built_mirrors_core:
-#    path: ../built_mirrors
+#    path: ../serializable_core
 #dependency_overrides:
 #  built_mirrors:
 #    path: ../built_mirrors


### PR DESCRIPTION
- upgrade `serializable_core` to version `0.11.0` since
  this version now generates from methods which now allows
  convert objects from generic values.
- move `SerializedName` to `built_mirrors` library since
  the serialized name is now generated at build time